### PR TITLE
Adhere to the new dictionary interface with `get`

### DIFF
--- a/plover_python_dictionary.py
+++ b/plover_python_dictionary.py
@@ -12,7 +12,6 @@ class PythonDictionary(StenoDictionary):
 
     def __init__(self):
         super(PythonDictionary, self).__init__()
-        self._mod = None
         self._lookup = None
         self._reverse_lookup = None
 
@@ -36,7 +35,6 @@ class PythonDictionary(StenoDictionary):
         self._reverse_lookup = getattr(mod, 'reverse_lookup', lambda x: ())
         if not isinstance(self._reverse_lookup, type(lambda x: x)):
             raise DictionaryLoaderException('Invalid dictionary: invalid `reverse_lookup\' function: %s\n' % str(reverse_lookup))
-        self._mod = mod
 
     def __setitem__(self, key, value):
         raise NotImplementedError()
@@ -46,6 +44,12 @@ class PythonDictionary(StenoDictionary):
 
     def __getitem__(self, key):
         return self._lookup(key)
+
+    def get(self, key, fallback=None):
+        try:
+            return self[key]
+        except KeyError:
+            return fallback
 
     def reverse_lookup(self, value):
         return self._reverse_lookup(value)


### PR DESCRIPTION
The problem is introduced commit
https://github.com/openstenoproject/plover/commit/1fc1e313c724fe0d8676e35294296cb196f79c0b,
where it adds a `get` method that delegates to the dictionary. This
dictionary doesn't have a `get` method, so it uses the default
implementation, which is wrong here.

This could also be fixed by having `StenoDictionary.get` call
`StenoDictionary.__getitem__` by default, since we currently do the
right thing for `__getitem__` in this dictionary.