### PR TITLE
dic.reverse_lookup() returns lists, not tuples.

### DIFF
--- a/plover_python_dictionary.py
+++ b/plover_python_dictionary.py
@@ -31,7 +31,7 @@ class PythonDictionary(StenoDictionary):
         self._lookup = getattr(mod, 'lookup', None)
         if not isinstance(self._lookup, type(lambda x: x)):
             raise ValueError('missing or invalid `lookup\' function: %s\n' % str(lookup))
-        self._reverse_lookup = getattr(mod, 'reverse_lookup', lambda x: ())
+        self._reverse_lookup = getattr(mod, 'reverse_lookup', lambda x: [])
         if not isinstance(self._reverse_lookup, type(lambda x: x)):
             raise ValueError('invalid `reverse_lookup\' function: %s\n' % str(reverse_lookup))
         self._mod = mod

--- a/test/test_blackbox.py
+++ b/test/test_blackbox.py
@@ -73,7 +73,7 @@ class BlackboxTest(unittest.TestCase):
         self.assertEqual(d.get(('STR',)), None)
         self.assertEqual(d[('STR*', 'STR')], 'STR')
         self.assertEqual(d.get(('STR*', 'STR')), 'STR')
-        self.assertEqual(d.reverse_lookup('STR'), ())
+        self.assertEqual(d.reverse_lookup('STR'), [])
         self.dictionary.set_dicts([d] + self.dictionary.dicts)
         self.dictionary.set(normalize_steno('STR'), u'center')
         for steno in (


### PR DESCRIPTION
dic.reverse_lookup() returns a list instead of a tuple.

This commit changes the behaviour for reverse_lookup() on unknown keys.

If Python dictionary modules exist which return tuples
on reverse_lookup(), that should be raised as a bug against
those modules.