### PR TITLE
Use importlib instead of exec

### DIFF
--- a/plover_python_dictionary.py
+++ b/plover_python_dictionary.py
@@ -3,11 +3,10 @@
 import typing
 import importlib.util
 import sys
-import types
 import os
 
 from plover.steno_dictionary import StenoDictionary
-
+from plover import log
 
 class PythonDictionary(StenoDictionary):
 
@@ -20,8 +19,9 @@ class PythonDictionary(StenoDictionary):
         self._reverse_lookup = None
         self.readonly = True
 
-    def _load(self, filename):
-        print(f"Loading {filename}")
+    def _load(self, filename): 
+        log.info("loading Python dictionary: %s", filename)
+        
         module_name = os.path.splitext(os.path.basename(filename))[0]
 
         spec = importlib.util.spec_from_file_location(module_name, filename)

--- a/plover_python_dictionary.py
+++ b/plover_python_dictionary.py
@@ -22,7 +22,7 @@ class PythonDictionary(StenoDictionary):
     def _load(self, filename): 
         log.info("loading Python dictionary: %s", filename)
         
-        module_name = os.path.splitext(os.path.basename(filename))[0]
+        module_name = filename # include full path
 
         spec = importlib.util.spec_from_file_location(module_name, filename)
         if spec is None or spec.loader is None:

--- a/plover_python_dictionary.py
+++ b/plover_python_dictionary.py
@@ -21,6 +21,7 @@ class PythonDictionary(StenoDictionary):
         self.readonly = True
 
     def _load(self, filename):
+        print(f"Loading {filename}")
         module_name = os.path.splitext(os.path.basename(filename))[0]
 
         spec = importlib.util.spec_from_file_location(module_name, filename)
@@ -47,14 +48,15 @@ class PythonDictionary(StenoDictionary):
         self._lookup = lookup
         self._longest_key = longest_key
         self._reverse_lookup = reverse_lookup
-        def __contains__(self, key):
-            if len(key) > self._longest_key:
-                return False
-            try:
-                self._lookup(key)
-            except KeyError:
-                return False
-            return True
+
+    def __contains__(self, key):
+        if len(key) > self._longest_key:
+            return False
+        try:
+            self._lookup(key)
+        except KeyError:
+            return False
+        return True
 
     def __getitem__(self, key):
         if len(key) > self._longest_key:


### PR DESCRIPTION
This PR removed the old use of exec for loading python dictionaries to instead using importlib. No changes are required to any dictionaries nor Plover.
  
Why
- Improves safety and maintainability by avoiding exec
- Integrates plugins/modules cleanly with Python’s import system (sys.modules)
- Better debugging support (tracebacks, see #10 )
- Follows Python's module system, instead of exec dumping everything into a flat dict (this is how additional python code should be loaded)
- exec can run any arbitrary Python code, importlib constrains behavior to well-formed Python modules
- Most other plugin systems use this same system, including setuptools
  
Overall this makes the code safer, helps dictionary developers, and makes it generally easier to maintain, with zero loss in functionality and no required changes to any other code including dictionaries and Plover.